### PR TITLE
Add request_id to Request event, modifications to work with the node

### DIFF
--- a/trusted_oracle/lib.rs
+++ b/trusted_oracle/lib.rs
@@ -4,7 +4,7 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod trusted_oracle {
-    use ink_storage::collections::{HashMap};
+    use ink_storage::collections::HashMap;
 
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(::scale_info::TypeInfo))]
@@ -84,7 +84,7 @@ mod trusted_oracle {
         #[ink(topic)]
         request_id: u64,
         to: AccountId,
-        result: OracleResult
+        result: OracleResult,
     }
 
     #[ink(storage)]
@@ -105,17 +105,19 @@ mod trusted_oracle {
         min_valid_period: u32,
         /// Maximum period for request timeout
         max_valid_period: u32,
+        /// Oracle results for every request
+        oracle_results: HashMap<u64, i64>,
     }
 
     impl TrustedOracle {
-
         /// Init
         #[ink(constructor)]
         pub fn new(
             admin: AccountId,
             oracle: AccountId,
             min_valid_period: u32,
-            max_valid_period: u32) -> Self {
+            max_valid_period: u32,
+        ) -> Self {
             Self {
                 admin: admin,
                 authorized_users: HashMap::new(),
@@ -125,6 +127,7 @@ mod trusted_oracle {
                 fee: (0 as u128).into(),
                 min_valid_period,
                 max_valid_period,
+                oracle_results: HashMap::new(),
             }
         }
 
@@ -132,7 +135,7 @@ mod trusted_oracle {
         #[ink(constructor)]
         pub fn default() -> Self {
             let caller = Self::env().caller();
-            let mut authorized_users: HashMap<AccountId,()> = HashMap::new();
+            let mut authorized_users: HashMap<AccountId, ()> = HashMap::new();
             authorized_users.insert(caller, ());
             Self {
                 admin: caller,
@@ -143,6 +146,7 @@ mod trusted_oracle {
                 fee: (0 as u128).into(),
                 min_valid_period: 10,
                 max_valid_period: 100,
+                oracle_results: HashMap::new(),
             }
         }
 
@@ -197,10 +201,12 @@ mod trusted_oracle {
 
         /// Deliver the oracle result
         #[ink(message)]
-        pub fn callback(&mut self,
+        pub fn callback(
+            &mut self,
             request_id: u64,
             callback_addr: AccountId,
-            result: OracleResult) -> Result<(),Error> {
+            result: OracleResult,
+        ) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.authorized_oracle {
@@ -251,10 +257,8 @@ mod trusted_oracle {
             // method 2:
             // https://paritytech.github.io/ink/ink_env/call/fn.build_call.html
             //
-            use ink_env::call::{build_call, Selector, ExecutionInput};
-            let selector = Selector::new([
-                0xB1, 0x6B, 0x00, 0xB5,
-            ]);
+            use ink_env::call::{build_call, ExecutionInput, Selector};
+            let selector = Selector::new([0xB1, 0x6B, 0x00, 0xB5]);
             let callback = build_call::<ink_env::DefaultEnvironment>()
                 .callee(callback_addr)
                 .gas_limit(1_000_000)
@@ -276,15 +280,62 @@ mod trusted_oracle {
 
             // remove request from storage
             self.requests.take(&request_id);
-            let event = CallbackComplete{request_id, to: callback_addr, result};
+            let event = CallbackComplete {
+                request_id,
+                to: callback_addr,
+                result,
+            };
             self.env().emit_event(event);
             Ok(())
         }
 
+        /// Simpler callback that sets the variable in the contract.
+        #[ink(message)]
+        pub fn simple_callback(
+            &mut self,
+            request_id: u64,
+            callback_addr: AccountId,
+            result: OracleResult,
+        ) -> Result<(), Error> {
+            let from = self.env().caller();
+
+            if from != self.authorized_oracle {
+                return Err(Error::Unauthorized);
+            }
+
+            // check if request_id has expired
+            if self.oracle_results.contains_key(&request_id) {
+                return Err(Error::RequestExpired);
+            }
+
+            // Write the result to result HashMap
+            if let OracleResult::Numeric(value) = result {
+                self.oracle_results.insert(request_id, value);
+            }
+
+            // remove request from storage
+            self.requests.take(&request_id);
+            let event = CallbackComplete {
+                request_id,
+                to: callback_addr,
+                result,
+            };
+            self.env().emit_event(event);
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn oracle_results(&self, request_id: u64) -> i64 {
+            if let Some(value) = self.oracle_results.get(&request_id) {
+                *value
+            } else {
+                return -1;
+            }
+        }
 
         /// Distribute the rewards to the oracle.
         #[ink(message)]
-        pub fn claim_rewards(&mut self) -> Result<(),Error>{
+        pub fn claim_rewards(&mut self) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.authorized_oracle {
@@ -301,7 +352,7 @@ mod trusted_oracle {
 
         /// Distribute the rewards to the oracle.
         #[ink(message)]
-        pub fn set_oracle(&mut self, new_oracle: AccountId) -> Result<(),Error> {
+        pub fn set_oracle(&mut self, new_oracle: AccountId) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.admin {
@@ -313,13 +364,13 @@ mod trusted_oracle {
 
             // set new oracle
             self.authorized_oracle = new_oracle;
-            self.env().emit_event(OracleSet{oracle: new_oracle});
+            self.env().emit_event(OracleSet { oracle: new_oracle });
             Ok(())
         }
 
         /// Change the per-request fee.
         #[ink(message)]
-        pub fn set_fee(&mut self, new_fee: Balance) -> Result<(),Error> {
+        pub fn set_fee(&mut self, new_fee: Balance) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.admin {
@@ -328,14 +379,13 @@ mod trusted_oracle {
 
             let old_fee = self.fee.clone();
             self.fee = new_fee;
-            self.env().emit_event(FeeChanged{old_fee, new_fee});
+            self.env().emit_event(FeeChanged { old_fee, new_fee });
             Ok(())
         }
 
-
         /// Add user to the oracle contract
         #[ink(message)]
-        pub fn add_user(&mut self, user: AccountId) -> Result<(),Error> {
+        pub fn add_user(&mut self, user: AccountId) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.admin {
@@ -344,14 +394,13 @@ mod trusted_oracle {
 
             // add the user
             self.authorized_users.insert(user.clone(), ());
-            self.env().emit_event(UserAdded{user});
+            self.env().emit_event(UserAdded { user });
             Ok(())
         }
 
-
         /// Remove user from the oracle contract
         #[ink(message)]
-        pub fn remove_user(&mut self, user: AccountId) -> Result<(),Error> {
+        pub fn remove_user(&mut self, user: AccountId) -> Result<(), Error> {
             let from = self.env().caller();
 
             if from != self.admin {
@@ -360,13 +409,13 @@ mod trusted_oracle {
 
             // remove the user
             self.authorized_users.take(&user);
-            self.env().emit_event(UserRemoved{user});
+            self.env().emit_event(UserRemoved { user });
             Ok(())
         }
 
         /// Remove expired request to free contract storage
         #[ink(message)]
-        pub fn clear_expired(&mut self, request_id: u64) -> Result<(),Error> {
+        pub fn clear_expired(&mut self, request_id: u64) -> Result<(), Error> {
             if let Some(request) = self.requests.get(&request_id) {
                 let (user_id, valid_till, fee) = request;
                 if *valid_till < self.env().block_number() {
@@ -386,53 +435,57 @@ mod trusted_oracle {
         //
 
         // TODO: check if this is private & internal only
-        fn claim_(&mut self) -> Result<(),Error> {
+        fn claim_(&mut self) -> Result<(), Error> {
             let balance = self.env().balance();
             if balance > (0 as u128).into() {
                 let tx = self.env().transfer(self.authorized_oracle, balance);
                 return match tx {
                     Ok(_) => {
-                        let event = RewardsClaimed{
+                        let event = RewardsClaimed {
                             oracle: self.authorized_oracle,
-                            amount: balance
+                            amount: balance,
                         };
                         self.env().emit_event(event);
                         Ok(())
-                    },
-                    Err(err) => {
-                        match err {
-                            ink_env::Error::BelowSubsistenceThreshold =>
-                                Err(Error::BelowSubsistenceThreshold),
-                            _ => Err(Error::TransferFailed),
-                        }
                     }
-                }
+                    Err(err) => match err {
+                        ink_env::Error::BelowSubsistenceThreshold => {
+                            Err(Error::BelowSubsistenceThreshold)
+                        }
+                        _ => Err(Error::TransferFailed),
+                    },
+                };
             }
             Ok(())
         }
 
         // TODO: check if this is private & internal only
-        fn refund_(&mut self, request_id: u64, user_id: AccountId, fee: Balance) -> Result<(),Error> {
+        fn refund_(
+            &mut self,
+            request_id: u64,
+            user_id: AccountId,
+            fee: Balance,
+        ) -> Result<(), Error> {
             if fee > (0 as u128).into() {
                 if self.env().balance() < fee {
                     return Err(Error::InsufficientFunds);
                 }
                 if let Err(err) = self.env().transfer(user_id, fee) {
                     return match err {
-                        ink_env::Error::BelowSubsistenceThreshold =>
-                            Err(Error::BelowSubsistenceThreshold),
+                        ink_env::Error::BelowSubsistenceThreshold => {
+                            Err(Error::BelowSubsistenceThreshold)
+                        }
                         _ => Err(Error::TransferFailed),
-                    }
+                    };
                 }
             }
-            let event = RequestInvalidated{
+            let event = RequestInvalidated {
                 request_id,
-                refunded: fee
+                refunded: fee,
             };
             self.env().emit_event(event);
             Ok(())
         }
-
     }
 
     #[cfg(test)]
@@ -442,7 +495,6 @@ mod trusted_oracle {
 
         extern crate hex;
         use hex::FromHex;
-
 
         #[ink::test]
         fn test_defaults() {
@@ -463,7 +515,6 @@ mod trusted_oracle {
             let pql_hash = sample_ipfs_hash();
             contract.request(pql_hash, 10);
         }
-
 
         #[ink::test]
         fn test_make_paid_request() {
@@ -554,14 +605,12 @@ mod trusted_oracle {
             // assert_eq!(get_balance(accounts.alice), fee);
         }
 
-
         //
         // helper functions
         //
         const DEFAULT_ENDOWMENT: Balance = 1_000_000;
         const DEFAULT_GAS_LIMIT: Balance = 1_000_000;
-        fn default_accounts(
-        ) -> ink_env::test::DefaultAccounts<ink_env::DefaultEnvironment> {
+        fn default_accounts() -> ink_env::test::DefaultAccounts<ink_env::DefaultEnvironment> {
             ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                 .expect("off-chain environment should have been initialized already")
         }
@@ -577,9 +626,7 @@ mod trusted_oracle {
         }
 
         fn set_balance(account_id: AccountId, balance: Balance) {
-            ink_env::test::set_account_balance::<ink_env::DefaultEnvironment>(
-                account_id, balance,
-            )
+            ink_env::test::set_account_balance::<ink_env::DefaultEnvironment>(account_id, balance)
                 .expect("Cannot set account balance");
         }
 
@@ -589,10 +636,9 @@ mod trusted_oracle {
         }
 
         fn contract_id() -> AccountId {
-            ink_env::test::get_current_contract_account_id::<ink_env::DefaultEnvironment>(
-            )
+            ink_env::test::get_current_contract_account_id::<ink_env::DefaultEnvironment>()
                 .expect("Cannot get contract id")
-         }
+        }
 
         fn sample_ipfs_hash() -> Hash {
             // first 2 bytes omitted
@@ -600,7 +646,5 @@ mod trusted_oracle {
             let decoded = <[u8; 32]>::from_hex(input).expect("Decoding failed");
             Hash::from(decoded)
         }
-
     }
-
 }


### PR DESCRIPTION
- adds a `request_id` to Request event
- removes `valid_till` computation on-chain as this does not work on the node. `valid_period` currently stands for the last block that the request is valid and should be computed off-chain.
- adds a `simple_callback` function which sets the `oracle_results` in the contract. This is the first step towards the oracle as the normal `callback` does not work yet.
- rust-analyzer performed some formatting.